### PR TITLE
Add possibility to define 'monasca_url' in config file, explicitly

### DIFF
--- a/agent.yaml.template
+++ b/agent.yaml.template
@@ -16,6 +16,8 @@ Api:
   # Keystone API URL: URL for the Keystone server to use
   # Example: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v3/
   keystone_url: {args.keystone_url}
+  # Monasca API URL (explicit value, no matter what is included in Keystone service catalog)
+  monasca_url: {args.monasca_url}
   # Domain id to be used to resolve username
   user_domain_id: {args.user_domain_id}
   # Domain name to be used to resolve username

--- a/monasca_agent/common/keystone.py
+++ b/monasca_agent/common/keystone.py
@@ -69,7 +69,8 @@ class Keystone(object):
             self.get_token()
 
         if self._keystone_client:
-            return self._keystone_client.monasca_url
+            # get 'monasca_url' from config file, if explicitly defined
+            return self.config.get('monasca_url', self._keystone_client.monasca_url)
         else:
             return None
 


### PR DESCRIPTION
#### Reviewers

@jesuspg 
#### Description

Add possibility to define 'monasca_url' in config file, explicitly. This is needed in case Keystone service catalog is not properly configured or the 'monitoring' entry does not refer to Monasca service.
#### Testing

Verified in FIWARE Lab.
