### PR TITLE
Update disk.yaml

### DIFF
--- a/conf.d/disk.yaml
+++ b/conf.d/disk.yaml
@@ -21,4 +21,4 @@ instances:
       # device_blacklist_re: .*\/dev\/mapper\/lxc-box.*
 
       # For disk metrics it is also possible to ignore entire filesystem types
-      ignore_filesystem_types: cgroup,configfs,debugfs,devpts,devtmpfs,fusectl,hugetlbfs,proc,pstore,rpc_pipefs,securityfs,sysfs,tmpfs,udevfs,iso9660
+      ignore_filesystem_types: cgroup,configfs,debugfs,devpts,devtmpfs,fusectl,hugetlbfs,proc,pstore,rpc_pipefs,securityfs,sysfs,tmpfs,udevfs,iso9660,tracefs,netns,nsfs


### PR DESCRIPTION
There are following errors:
ERROR | collector | monasca_agent.collector.checks.check.disk(check.py:564) | Check 'disk' instance #0 failed
Traceback (most recent call last): OSError: [Errno 13] Permission denied: '/sys/kernel/debug/tracing'
Solution:
We need to add “tracefs” in “ignore_filesystem_types” in “/etc/monasca/agent/conf.d/disk.yaml” file to resolve above issue.

Error:
st = os.statvfs(path) OSError: [Errno 13] Permission denied: '/run/docker/
Solution:
We need to add “netns,nsfs” in “ignore_filesystem_types” in “/etc/monasca/agent/conf.d/disk.yaml” file